### PR TITLE
Added support for "mixed" kwformat type

### DIFF
--- a/examples/mixeddata/mixeddata.tvpd
+++ b/examples/mixeddata/mixeddata.tvpd
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<vpd>
+  <name>FILENAME</name>
+  <size>16kb</size>
+  <VD>01</VD>
+  <record name="VINI">
+    <rdesc>The VINI record</rdesc>
+    <keyword name="MX">
+      <kwdesc>Mixed Data Keyword</kwdesc>
+      <kwformat>mixed</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>
+        <hex>
+          0123456789ABCDEF
+        </hex>
+        <ascii>STRING</ascii>
+        <hex>
+          FEEDB0B0 DEADBEEF
+        </hex>
+      </kwdata>
+    </keyword>
+    <keyword name="AS">
+      <kwdesc>The ascii keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>20</kwlen>
+      <kwdata>This is text data</kwdata>
+    </keyword>
+    <keyword name="HX">
+      <kwdesc>The Hex keyword</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>00000000</kwdata>
+    </keyword>
+  </record>
+</vpd>


### PR DESCRIPTION
  - Mixed type allows for hex or ascii tags in kwdata tag
  - Added checking of new xml structure
  - Added example of mixed data usage
  - Fixed a bug with hex input data with white space that resulted in
    data not being padded out to the length of the kw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/vpdtools/4)
<!-- Reviewable:end -->
