### PR TITLE
Create P9 System Planar VPD Template Example Version 2

### DIFF
--- a/examples/p9/sysplanar32_ddr4/readme
+++ b/examples/p9/sysplanar32_ddr4/readme
@@ -1,0 +1,24 @@
+This is a P9 system planar VPD template version 1.
+
+This template version, a user would create a top layer of the vpd template.
+This top layer template then pulls records data from different files,
+record files.
+
+Each record file contains keywords and data for each keyowrd within the file.
+
+
+Top layer VPD template:
+sysplanar32_ddr4.tvpd
+
+
+Record Templates:
+openPower_memd_sample.xml
+openPower_mer0_sample.xml
+openPower_opfr_sample.xml
+openPower_osys_sample.xml
+openPower_ver0_sample.xml
+openPower_vini_sample.xml
+openPower_vmsc_sample.xml
+openPower_vndr_sample.xml
+openPower_vrtn_sample.xml
+

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ck_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ck_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="CK">
+   <kwdesc>Memory Clock Enable keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>136</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j0_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j0_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J0">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j1_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j1_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J1">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j2_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j2_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J2">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j3_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j3_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J3">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j4_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j4_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J4">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j5_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j5_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J5">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j6_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j6_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J6">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j7_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j7_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J7">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j8_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j8_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J8">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j9_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_j9_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="J9">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ja_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ja_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JA">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jb_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jb_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JB">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jc_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jc_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JC">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jd_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jd_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JD">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_je_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_je_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JE">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jf_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jf_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JF">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jg_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jg_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JG">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jh_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jh_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JH">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ji_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ji_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JI">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jj_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jj_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JJ">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jk_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jk_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JK">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jl_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jl_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JL">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jm_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jm_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JM">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jn_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jn_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JN">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jo_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jo_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JO">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jp_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jp_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JP">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jq_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jq_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JQ">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jr_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jr_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JR">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_js_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_js_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JS">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jt_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jt_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JT">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ju_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_ju_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JU">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jv_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jv_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JV">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jw_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jw_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JW">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jx_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jx_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JX">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jy_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jy_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JY">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jz_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_jz_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="JZ">
+   <kwdesc>Memory Rotator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_mr_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_mr_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="MR">
+   <kwdesc>Memory Rotator Mapper keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_mt_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_mt_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="MT">
+   <kwdesc>Memory Terminator Mapper keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q0_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q0_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q0">
+   <kwdesc>Memory DQ Data Mapper keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>36</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q1_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q1_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q1">
+   <kwdesc>Memory DQ Data1 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q2_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q2_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q2">
+   <kwdesc>Memory DQ Data2 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q3_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q3_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q3">
+   <kwdesc>Memory DQ Data3 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q4_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q4_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q4">
+   <kwdesc>Memory DQ Data4 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q5_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q5_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q5">
+   <kwdesc>Memory DQ Data5 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q6_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q6_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q6">
+   <kwdesc>Memory DQ Data6 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q7_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q7_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q7">
+   <kwdesc>Memory DQ Data7 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q8_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q8_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q8">
+   <kwdesc>Memory DQ Data8 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q9_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_q9_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="Q9">
+   <kwdesc>Memory DQ Data9 keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>160</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_sample.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0"?>
+<record name="MEMD">
+    <rdesc>Memory data record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>MEMD</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>03</kwdata>
+    </keyword>
+
+    <keyword name="VM">
+      <ktvpdfile>openPower_memd_vm_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="MR">
+      <ktvpdfile>openPower_memd_mr_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J0">
+      <ktvpdfile>openPower_memd_j0_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J1">
+      <ktvpdfile>openPower_memd_j1_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J2">
+      <ktvpdfile>openPower_memd_j2_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J3">
+      <ktvpdfile>openPower_memd_j3_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J4">
+      <ktvpdfile>openPower_memd_j4_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J5">
+      <ktvpdfile>openPower_memd_j5_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J6">
+      <ktvpdfile>openPower_memd_j6_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J7">
+      <ktvpdfile>openPower_memd_j7_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J8">
+      <ktvpdfile>openPower_memd_j8_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="J9">
+      <ktvpdfile>openPower_memd_j9_sample.xml</ktvpdfile>
+    </keyword>
+
+
+    <keyword name="JA">
+      <ktvpdfile>openPower_memd_ja_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JB">
+      <ktvpdfile>openPower_memd_jb_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JC">
+      <ktvpdfile>openPower_memd_jc_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JD">
+      <ktvpdfile>openPower_memd_jd_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JE">
+      <ktvpdfile>openPower_memd_je_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JF">
+      <ktvpdfile>openPower_memd_jf_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JG">
+      <ktvpdfile>openPower_memd_jg_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JH">
+      <ktvpdfile>openPower_memd_jh_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JI">
+      <ktvpdfile>openPower_memd_ji_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JJ">
+      <ktvpdfile>openPower_memd_jj_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JK">
+      <ktvpdfile>openPower_memd_jk_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JL">
+      <ktvpdfile>openPower_memd_jl_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JM">
+      <ktvpdfile>openPower_memd_jm_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JN">
+      <ktvpdfile>openPower_memd_jn_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JO">
+      <ktvpdfile>openPower_memd_jo_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JP">
+      <ktvpdfile>openPower_memd_jp_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JQ">
+      <ktvpdfile>openPower_memd_jq_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JR">
+      <ktvpdfile>openPower_memd_jr_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JS">
+      <ktvpdfile>openPower_memd_js_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JT">
+      <ktvpdfile>openPower_memd_jt_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JU">
+      <ktvpdfile>openPower_memd_ju_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JV">
+      <ktvpdfile>openPower_memd_jv_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JW">
+      <ktvpdfile>openPower_memd_jw_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JX">
+      <ktvpdfile>openPower_memd_jx_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JY">
+      <ktvpdfile>openPower_memd_jy_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="JZ">
+      <ktvpdfile>openPower_memd_jz_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="MT">
+      <ktvpdfile>openPower_memd_mt_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X0">
+      <ktvpdfile>openPower_memd_x0_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X1">
+      <ktvpdfile>openPower_memd_x1_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X2">
+      <ktvpdfile>openPower_memd_x2_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X3">
+      <ktvpdfile>openPower_memd_x3_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X4">
+      <ktvpdfile>openPower_memd_x4_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X5">
+      <ktvpdfile>openPower_memd_x5_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X6">
+      <ktvpdfile>openPower_memd_x6_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X7">
+      <ktvpdfile>openPower_memd_x7_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X8">
+      <ktvpdfile>openPower_memd_x8_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="X9">
+      <ktvpdfile>openPower_memd_x9_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XA">
+      <ktvpdfile>openPower_memd_xa_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XB">
+      <ktvpdfile>openPower_memd_xb_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XC">
+      <ktvpdfile>openPower_memd_xc_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XD">
+      <ktvpdfile>openPower_memd_xd_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XE">
+      <ktvpdfile>openPower_memd_xe_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XF">
+      <ktvpdfile>openPower_memd_xf_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XG">
+      <ktvpdfile>openPower_memd_xg_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XH">
+      <ktvpdfile>openPower_memd_xh_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XI">
+      <ktvpdfile>openPower_memd_xi_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XJ">
+      <ktvpdfile>openPower_memd_xj_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XK">
+      <ktvpdfile>openPower_memd_xk_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XL">
+      <ktvpdfile>openPower_memd_xl_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XM">
+      <ktvpdfile>openPower_memd_xm_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XN">
+      <ktvpdfile>openPower_memd_xn_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XO">
+      <ktvpdfile>openPower_memd_xo_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XP">
+      <ktvpdfile>openPower_memd_xp_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XQ">
+      <ktvpdfile>openPower_memd_xq_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XR">
+      <ktvpdfile>openPower_memd_xr_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XS">
+      <ktvpdfile>openPower_memd_xs_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XT">
+      <ktvpdfile>openPower_memd_xt_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XU">
+      <ktvpdfile>openPower_memd_xu_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XV">
+      <ktvpdfile>openPower_memd_xv_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XW">
+      <ktvpdfile>openPower_memd_xw_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XX">
+      <ktvpdfile>openPower_memd_xx_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XY">
+      <ktvpdfile>openPower_memd_xy_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="XZ">
+      <ktvpdfile>openPower_memd_xz_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="CK">
+      <ktvpdfile>openPower_memd_ck_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q0">
+      <ktvpdfile>openPower_memd_q0_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q1">
+      <ktvpdfile>openPower_memd_q1_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q2">
+      <ktvpdfile>openPower_memd_q2_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q3">
+      <ktvpdfile>openPower_memd_q3_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q4">
+      <ktvpdfile>openPower_memd_q4_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q5">
+      <ktvpdfile>openPower_memd_q5_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q6">
+      <ktvpdfile>openPower_memd_q6_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q7">
+      <ktvpdfile>openPower_memd_q7_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q8">
+      <ktvpdfile>openPower_memd_q8_sample.xml</ktvpdfile>
+    </keyword>
+
+    <keyword name="Q9">
+      <ktvpdfile>openPower_memd_q9_sample.xml</ktvpdfile>
+    </keyword>
+
+</record>
+
+

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_vm_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_vm_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="VM">
+   <kwdesc>Memory Data Version keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>4</kwlen>
+   <kwdata>00000000</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x0_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x0_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X0">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x1_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x1_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X1">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x2_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x2_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X2">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x3_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x3_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X3">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x4_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x4_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X4">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x5_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x5_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X5">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x6_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x6_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X6">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x7_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x7_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X7">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x8_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x8_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X8">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x9_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_x9_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="X9">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xa_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xa_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XA">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xb_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xb_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XB">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xc_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xc_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XC">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xd_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xd_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XD">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xe_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xe_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XE">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xf_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xf_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XF">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xg_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xg_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XG">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xh_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xh_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XH">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xi_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xi_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XI">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xj_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xj_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XJ">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xk_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xk_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XK">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xl_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xl_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XL">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xm_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xm_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XM">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xn_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xn_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XN">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xo_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xo_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XO">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xp_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xp_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XP">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xq_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xq_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XQ">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xr_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xr_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XR">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xs_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xs_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XS">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xt_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xt_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XT">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xu_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xu_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XU">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xv_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xv_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XV">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xw_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xw_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XW">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xx_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xx_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XX">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xy_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xy_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XY">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xz_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_memd_xz_sample.xml
@@ -1,0 +1,6 @@
+<keyword name="XZ">
+   <kwdesc>Memory Terminator Data keyword</kwdesc>
+   <kwformat>hex</kwformat>
+   <kwlen>255</kwlen>
+   <kwdata>00</kwdata>
+</keyword>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_mer0_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_mer0_sample.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="MER0">
+    <rdesc>The Manufacturing repair data record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>MER0</kwdata>
+    </keyword>
+
+    <keyword name="#I">
+      <kwdesc>Repair Data </kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>198</kwlen>
+      <kwdata>455202062000</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_opfr_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_opfr_sample.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="OPFR">
+    <rdesc>The OPFR record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OPFR</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>02</kwdata>
+    </keyword>
+
+    <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>SYSTEM PLANAR   </kwdata>
+    </keyword>
+
+    <keyword name="VP">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="VS">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="MB">
+      <kwdesc>Manufacturing Build Date</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_osys_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_osys_sample.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<vpd>
+  <!-- 2017/08-14 myl:  Adding UD keyword for UUID per story 178386 -->
+  <!--                  Change VD value to 02                       -->
+
+  <record name="OSYS">
+    <rdesc>The OpenPower System Record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OSYS</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>02</kwdata>
+    </keyword>
+
+    <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>SYSTEM          </kwdata>
+    </keyword>
+
+    <keyword name="MM">
+      <kwdesc>Machine Type Model</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="SS">
+      <kwdesc>System Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="ET">
+      <kwdesc>Enclosure Type</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>02</kwdata>
+    </keyword>
+
+    <keyword name="UD">
+      <kwdesc>UUID</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>17</kwlen>
+      <kwdata>0100000000000000000000000000000000</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_sysplanar32_ddr4.tvpd
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_sysplanar32_ddr4.tvpd
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<vpd>
+  <!-- OpenPower P9 system Planar with direct attached ISDIMM FRU VPD-->
+  <!-- DDR4 ISDIMMs are plugged onto this system board -->
+
+  <name>FILENAME</name>
+  <size>64kb</size>
+  <VD>01</VD>
+
+  <record name="VINI">
+    <rtvpdfile>openPower_vini_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="OSYS">
+    <rtvpdfile>openPower_osys_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="OPFR">
+    <rtvpdfile>openPower_opfr_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>openPower_vndr_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="MEMD">
+    <rtvpdfile>openPower_memd_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="VER0">
+    <rtvpdfile>openPower_ver0_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="MER0">
+    <rtvpdfile>openPower_mer0_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="VMSC">
+    <rtvpdfile>openPower_vmsc_sample.xml</rtvpdfile>
+  </record>
+
+  <record name="VRTN">
+    <rtvpdfile>openPower_vrtn_sample.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_ver0_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_ver0_sample.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<vpd>
+  <record name="VER0">
+    <rdesc>The Vendor repair data record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VER0</kwdata>
+    </keyword>
+
+    <keyword name="#I">
+      <kwdesc>Repair Data </kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>198</kwlen>
+      <kwdata>455202062000</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_vini_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_vini_sample.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="VINI">
+    <rdesc>Initial VPD Record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VINI</kwdata>
+    </keyword>
+
+    <keyword name="DR">
+      <kwdesc>Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>SYSTEM PLANAR   </kwdata>
+    </keyword>
+    
+    <keyword name="CE">
+      <kwdesc>CCIN Extension</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>1</kwdata>
+    </keyword>
+
+    <keyword name="VZ">
+      <kwdesc>Overall VPD version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+    </keyword>
+
+    <keyword name="FN">
+      <kwdesc>FRU Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>7</kwlen>
+      <kwdata>0000000</kwdata>
+    </keyword>
+
+    <keyword name="PN">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>7</kwlen>
+      <kwdata>0000000</kwdata>
+    </keyword>
+
+    <keyword name="SN">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>12</kwlen>
+      <kwdata>000000000000</kwdata>
+    </keyword>
+
+    <keyword name="CC">
+      <kwdesc>Card CCIN Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>P0XX</kwdata>
+    </keyword>
+
+    <keyword name="HE">
+      <kwdesc>Hardware EC</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>0001</kwdata>
+    </keyword>
+
+    <keyword name="CT">
+      <kwdesc>Card Type</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>00000000</kwdata>
+    </keyword>
+
+    <keyword name="HW">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>0001</kwdata>
+    </keyword>
+
+    <keyword name="B3">
+      <kwdesc>Hardware Characteristics</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>6</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+    <keyword name="B4">
+      <kwdesc>Manufacturing FRU Control</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+    <keyword name="B7">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>12</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_vmsc_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_vmsc_sample.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="VMSC">
+    <rdesc>The VMSC record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VMSC</kwdata>
+    </keyword>
+
+    <keyword name="IN">
+      <kwdesc>Free Space for Software Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>205</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_vndr_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_vndr_sample.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="VNDR">
+    <rdesc>The VNDR record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>02</kwdata>
+    </keyword>
+
+    <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+    <keyword name="NV">
+      <kwdesc>NVLINK Configuration Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>255</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/openPower_vrtn_sample.xml
+++ b/examples/p9/sysplanar32_ddr4_v02/openPower_vrtn_sample.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<vpd>
+
+  <record name="VRTN">
+    <rdesc>The VRTN record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VRTN</kwdata>
+    </keyword>
+
+    <keyword name="SO">
+      <kwdesc>The SO keyword</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+    <keyword name="IN">
+      <kwdesc>Free Space for Sofware Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>254</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+    <keyword name="I2">
+      <kwdesc>Additional Free Space for Sofware Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>254</kwlen>
+      <kwdata>00</kwdata>
+    </keyword>
+
+  </record>
+
+</vpd>

--- a/examples/p9/sysplanar32_ddr4_v02/readme
+++ b/examples/p9/sysplanar32_ddr4_v02/readme
@@ -1,0 +1,117 @@
+This is a P9 system planar VPD template version 2.
+This version is created on August 22, 2017
+
+This template version, a user would create a top layer of the vpd template.
+This top layer template then pulls records data from different files,
+record files.
+
+Each record file, except memd record,  contains keywords and data for each keyowrd within the file.
+
+The memd record pull keyword data from different keywords files.  This make it easy to update
+each keyword data without impacting one another.
+
+
+Top layer VPD template:
+openPower_sysplanar32_ddr4.tvpd
+
+
+Record Templates:
+openPower_memd_sample.xml
+openPower_mer0_sample.xml
+openPower_opfr_sample.xml
+openPower_osys_sample.xml
+openPower_ver0_sample.xml
+openPower_vini_sample.xml
+openPower_vmsc_sample.xml
+openPower_vndr_sample.xml
+openPower_vrtn_sample.xml
+
+Keyword Templates
+openPower_memd_ck_sample.xml
+openPower_memd_j0_sample.xml
+openPower_memd_j1_sample.xml
+openPower_memd_j2_sample.xml
+openPower_memd_j3_sample.xml
+openPower_memd_j4_sample.xml
+openPower_memd_j5_sample.xml
+openPower_memd_j6_sample.xml
+openPower_memd_j7_sample.xml
+openPower_memd_j8_sample.xml
+openPower_memd_j9_sample.xml
+openPower_memd_ja_sample.xml
+openPower_memd_jb_sample.xml
+openPower_memd_jc_sample.xml
+openPower_memd_jd_sample.xml
+openPower_memd_je_sample.xml
+openPower_memd_jf_sample.xml
+openPower_memd_jg_sample.xml
+openPower_memd_jh_sample.xml
+openPower_memd_ji_sample.xml
+openPower_memd_jj_sample.xml
+openPower_memd_jk_sample.xml
+openPower_memd_jl_sample.xml
+openPower_memd_jm_sample.xml
+openPower_memd_jn_sample.xml
+openPower_memd_jo_sample.xml
+openPower_memd_jp_sample.xml
+openPower_memd_jq_sample.xml
+openPower_memd_jr_sample.xml
+openPower_memd_js_sample.xml
+openPower_memd_jt_sample.xml
+openPower_memd_ju_sample.xml
+openPower_memd_jv_sample.xml
+openPower_memd_jw_sample.xml
+openPower_memd_jx_sample.xml
+openPower_memd_jy_sample.xml
+openPower_memd_jz_sample.xml
+openPower_memd_mr_sample.xml
+openPower_memd_mt_sample.xml
+openPower_memd_q0_sample.xml
+openPower_memd_q1_sample.xml
+openPower_memd_q2_sample.xml
+openPower_memd_q3_sample.xml
+openPower_memd_q4_sample.xml
+openPower_memd_q5_sample.xml
+openPower_memd_q6_sample.xml
+openPower_memd_q7_sample.xml
+openPower_memd_q8_sample.xml
+openPower_memd_q9_sample.xml
+openPower_memd_vm_sample.xml
+openPower_memd_x0_sample.xml
+openPower_memd_x1_sample.xml
+openPower_memd_x2_sample.xml
+openPower_memd_x3_sample.xml
+openPower_memd_x4_sample.xml
+openPower_memd_x5_sample.xml
+openPower_memd_x6_sample.xml
+openPower_memd_x7_sample.xml
+openPower_memd_x8_sample.xml
+openPower_memd_x9_sample.xml
+openPower_memd_xa_sample.xml
+openPower_memd_xb_sample.xml
+openPower_memd_xc_sample.xml
+openPower_memd_xd_sample.xml
+openPower_memd_xe_sample.xml
+openPower_memd_xf_sample.xml
+openPower_memd_xg_sample.xml
+openPower_memd_xh_sample.xml
+openPower_memd_xi_sample.xml
+openPower_memd_xj_sample.xml
+openPower_memd_xk_sample.xml
+openPower_memd_xl_sample.xml
+openPower_memd_xm_sample.xml
+openPower_memd_xn_sample.xml
+openPower_memd_xo_sample.xml
+openPower_memd_xp_sample.xml
+openPower_memd_xq_sample.xml
+openPower_memd_xr_sample.xml
+openPower_memd_xs_sample.xml
+openPower_memd_xt_sample.xml
+openPower_memd_xu_sample.xml
+openPower_memd_xv_sample.xml
+openPower_memd_xw_sample.xml
+openPower_memd_xx_sample.xml
+openPower_memd_xy_sample.xml
+openPower_memd_xz_sample.xml
+
+


### PR DESCRIPTION
This example provide a user the capability of separating
keyword data into a different file.  The example shows
how memory record, memd, pull its keyword data from
different keyword data file.

bug:  NA
branch:  master

Signed-off-by: Michael Y. Lim <youhour@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/vpdtools/11)
<!-- Reviewable:end -->
