### PR TITLE
Add OpenBMC FRU VPD example

### DIFF
--- a/examples/p9/openBMC/openPower_obmc.tvpd
+++ b/examples/p9/openBMC/openPower_obmc.tvpd
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<vpd>
+  <!-- OpenBMC FRU VPD for P9 OpenPower Systems-->
+  <!-- Requires 4 Kbytes eeprom-->
+
+  <name>FILENAME</name>
+  <size>4kb</size>
+  <VD>01</VD>
+
+  <record name="VINI">
+    <rtvpdfile>openPower_obmc_vini_record.xml</rtvpdfile>
+  </record>
+
+  <record name="OPFR">
+    <rtvpdfile>openPower_obmc_opfr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>openPower_obmc_vndr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VMSC">
+    <rtvpdfile>openPower_obmc_vmsc_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VRTN">
+    <rtvpdfile>openPower_obmc_vrtn_record.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9/openBMC/openPower_obmc_opfr_record.xml
+++ b/examples/p9/openBMC/openPower_obmc_opfr_record.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+
+<record name="OPFR">
+<rdesc>The OPFR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OPFR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>03</kwdata>
+   </keyword>
+
+   <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>OPENBMC CARD    </kwdata>
+   </keyword>
+
+   <keyword name="VP">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="VS">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="MB">
+      <kwdesc>Manufacturing Build Date</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="UD">
+      <kwdesc>OpenBMC UUID</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>17</kwlen>
+      <kwdata>0100000000000000000000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="B1">
+      <kwdesc>Eight Ethernet MAC Addresses (8bytes each)</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>64</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9/openBMC/openPower_obmc_vini_record.xml
+++ b/examples/p9/openBMC/openPower_obmc_vini_record.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+
+<record name="VINI">
+<rdesc>Initial VPD Record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VINI</kwdata>
+   </keyword>
+
+   <keyword name="DR">
+      <kwdesc>Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>OPENBMC CARD    </kwdata>
+   </keyword>
+    
+   <keyword name="CE">
+      <kwdesc>CCIN Extension</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>1</kwdata>
+   </keyword>
+
+   <keyword name="VZ">
+      <kwdesc>Overall VPD version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>30</kwdata>
+   </keyword>
+
+   <keyword name="FN">
+      <kwdesc>FRU Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>7</kwlen>
+      <kwdata>0000000</kwdata>
+   </keyword>
+
+   <keyword name="PN">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>7</kwlen>
+      <kwdata>0000000</kwdata>
+   </keyword>
+
+   <keyword name="SN">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>12</kwlen>
+      <kwdata>000000000000</kwdata>
+   </keyword>
+
+   <keyword name="CC">
+      <kwdesc>Card CCIN Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>P0XX</kwdata>
+   </keyword>
+
+   <keyword name="HE">
+      <kwdesc>Hardware EC</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+   <keyword name="CT">
+      <kwdesc>Card Type</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>00000000</kwdata>
+   </keyword>
+
+   <keyword name="HW">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+   <keyword name="B3">
+      <kwdesc>Hardware Characteristics</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>6</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="B4">
+      <kwdesc>Manufacturing FRU Control</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="B7">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>12</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9/openBMC/openPower_obmc_vmsc_record.xml
+++ b/examples/p9/openBMC/openPower_obmc_vmsc_record.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<record name="VMSC">
+<rdesc>The VMSC record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VMSC</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Free Space for Software Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>205</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9/openBMC/openPower_obmc_vndr_record.xml
+++ b/examples/p9/openBMC/openPower_obmc_vndr_record.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<record name="VNDR">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9/openBMC/openPower_obmc_vrtn_record.xml
+++ b/examples/p9/openBMC/openPower_obmc_vrtn_record.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+
+<record name="VRTN">
+<rdesc>The VRTN record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VRTN</kwdata>
+   </keyword>
+
+   <keyword name="SO">
+      <kwdesc>The SO keyword</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Free Space for Sofware Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>254</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="I2">
+      <kwdesc>Additional Free Space for Sofware Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>254</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9/sysplanar32_ddr4/openPower_osys_sample.xml
+++ b/examples/p9/sysplanar32_ddr4/openPower_osys_sample.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <vpd>
-  <!-- 2017/08-14 myl:  Adding UD keyword for UUID per story 178386 -->
+  <!-- 2017-08-14 myl:  Adding UD keyword for UUID per story 178386 -->
   <!--                  Change VD value to 02                       -->
+  <!-- 2017-08-29 myl:  Revert the above changed on 8/14/17         -->
 
   <record name="OSYS">
     <rdesc>The OpenPower System Record</rdesc>
@@ -17,7 +18,7 @@
       <kwdesc>Record Version</kwdesc>
       <kwformat>ascii</kwformat>
       <kwlen>2</kwlen>
-      <kwdata>02</kwdata>
+      <kwdata>01</kwdata>
     </keyword>
 
     <keyword name="DR">
@@ -46,13 +47,6 @@
       <kwformat>hex</kwformat>
       <kwlen>1</kwlen>
       <kwdata>02</kwdata>
-    </keyword>
-
-    <keyword name="UD">
-      <kwdesc>UUID</kwdesc>
-      <kwformat>hex</kwformat>
-      <kwlen>17</kwlen>
-      <kwdata>0100000000000000000000000000000000</kwdata>
     </keyword>
 
   </record>


### PR DESCRIPTION
Adding OpenBMC FRU VPD example.
Also removing UD keyword from OSYS record in system VPD template.

bug:  NA
branch:  master

Signed-off-by: Michael Y. Lim <youhour@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/vpdtools/12)
<!-- Reviewable:end -->
