### PR TITLE
Adding FRU VPD Template Examples for P9 Prime FRU

### DIFF
--- a/examples/p9p/genericfru/p9p_openfru.tvpd
+++ b/examples/p9p/genericfru/p9p_openfru.tvpd
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+  <!-- OpenBMC FRU VPD for P9 Prime OpenPower Systems-->
+  <!-- Requires 4 Kbytes eeprom-->
+  <!-- myl:  2019-01-11:  Create-->
+
+<vpd>
+
+  <name>FILENAME</name>
+  <size>4kb</size>
+  <VD>01</VD>
+
+  <record name="OPFR">
+    <rtvpdfile>p9p_openfru_opfr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>p9p_openfru_vndr_record.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9p/genericfru/p9p_openfru_opfr_record.xml
+++ b/examples/p9p/genericfru/p9p_openfru_opfr_record.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="OPFR">
+<rdesc>The OPFR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OPFR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>04</kwdata>
+   </keyword>
+
+   <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>FRU Vendor</kwdata>
+   </keyword>
+
+   <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>FRU Description</kwdata>
+   </keyword>
+
+   <keyword name="VP">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="VS">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="MB">
+      <kwdesc>Manufacturing Build Date</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8</kwlen>
+      <kwdata>0120181225125959</kwdata>
+   </keyword>
+
+   <keyword name="VZ">
+      <kwdesc>Overall VPD version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="HE">
+      <kwdesc>Hardware EC</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+   <keyword name="HW">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/genericfru/p9p_openfru_vndr_record.xml
+++ b/examples/p9p/genericfru/p9p_openfru_vndr_record.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="VNDR">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/openbmc/p9p_obmc.tvpd
+++ b/examples/p9p/openbmc/p9p_obmc.tvpd
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!-- OpenBMC FRU VPD for P9 Prime OpenPower Systems-->
+<!-- myl:  2019-01-11:  Create-->
+
+<vpd>
+
+  <name>FILENAME</name>
+  <size>4kb</size>
+  <VD>01</VD>
+
+  <record name="OPFR">
+    <rtvpdfile>p9p_obmc_opfr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>p9p_obmc_vndr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VCFG">
+     <rtvpdfile>p9p_obmc_vcfg_record.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9p/openbmc/p9p_obmc_opfr_record.xml
+++ b/examples/p9p/openbmc/p9p_obmc_opfr_record.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="OPFR">
+<rdesc>The OPFR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OPFR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>04</kwdata>
+   </keyword>
+
+   <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>FRU Vendor</kwdata>
+   </keyword>
+
+   <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>OpenBMC Card</kwdata>
+   </keyword>
+
+   <keyword name="VP">
+      <kwdesc>Card Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="VS">
+      <kwdesc>Card Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+   </keyword>
+
+   <keyword name="MB">
+      <kwdesc>Manufacturing Build Date</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8</kwlen>
+      <kwdata>0120181225125959</kwdata>
+   </keyword>
+
+   <keyword name="VZ">
+      <kwdesc>Overall VPD version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="HE">
+      <kwdesc>Hardware EC</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+   <keyword name="HW">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>0001</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/openbmc/p9p_obmc_vcfg_record.xml
+++ b/examples/p9p/openbmc/p9p_obmc_vcfg_record.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="VCFG">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VCFG</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="B1">
+      <kwdesc>Base eMAC Address</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>64</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="NV">
+      <kwdesc>NVLink Configuration Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>255</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/openbmc/p9p_obmc_vndr_record.xml
+++ b/examples/p9p/openbmc/p9p_obmc_vndr_record.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="VNDR">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar.tvpd
+++ b/examples/p9p/sysplanar/p9p_sysplanar.tvpd
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!-- OpenPower P9 Prime system Planar-->
+<!-- myl:  2019-01-11:  Create -->
+
+<vpd>
+
+  <name>FILENAME</name>
+  <size>64kb</size>
+  <VD>01</VD>
+
+  <record name="OSYS">
+    <rtvpdfile>p9p_sysplanar_osys_record.xml</rtvpdfile>
+  </record>
+
+  <record name="OPFR">
+    <rtvpdfile>p9p_sysplanar_opfr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>p9p_sysplanar_vndr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VER0">
+    <rtvpdfile>p9p_sysplanar_ver0_record.xml</rtvpdfile>
+  </record>
+
+  <record name="MER0">
+    <rtvpdfile>p9p_sysplanar_mer0_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VCFG">
+    <rtvpdfile>p9p_sysplanar_vcfg_record.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9p/sysplanar/p9p_sysplanar_mer0_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_mer0_record.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!-- 2019-01-11 myl:  Create -->
+
+<record name="MER0">
+    <rdesc>The Manufacturing repair data record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>MER0</kwdata>
+    </keyword>
+
+    <keyword name="#I">
+      <kwdesc>Repair Data </kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>198</kwlen>
+      <kwdata>455202062000</kwdata>
+    </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar_opfr_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_opfr_record.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="OPFR">
+<rdesc>The OPFR record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OPFR</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>04</kwdata>
+    </keyword>
+
+    <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>FRU Vendor</kwdata>
+    </keyword>
+
+    <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>SYSTEM PLANAR</kwdata>
+    </keyword>
+
+    <keyword name="VP">
+      <kwdesc>FRU Part Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="VS">
+      <kwdesc>FRU Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="MB">
+      <kwdesc>Manufacturing Build Date</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8</kwlen>
+      <kwdata>0120181225125959</kwdata>
+    </keyword>
+
+    <keyword name="VZ">
+      <kwdesc>Overall VPD version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+    </keyword>
+
+    <keyword name="HE">
+      <kwdesc>Hardware EC</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>0001</kwdata>
+    </keyword>
+
+    <keyword name="HW">
+      <kwdesc>Hardware Level</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>0001</kwdata>
+    </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar_osys_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_osys_record.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!-- 2019-01-11 myl:  Create -->
+
+<record name="OSYS">
+<rdesc>The OpenPower System Record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>OSYS</kwdata>
+    </keyword>
+
+    <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>03</kwdata>
+    </keyword>
+
+    <keyword name="DR">
+      <kwdesc>FRU Description</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>SYSTEM</kwdata>
+    </keyword>
+
+    <keyword name="MM">
+      <kwdesc>Machine Type Model</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="SS">
+      <kwdesc>System Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="ET">
+      <kwdesc>Enclosure Type</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>02</kwdata>
+    </keyword>
+
+    <keyword name="VN">
+      <kwdesc>Vendor Name</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>System Vendor</kwdata>
+    </keyword>
+
+    <keyword name="AT">
+      <kwdesc>Asset Tag</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="UD">
+      <kwdesc>UUID</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>17</kwlen>
+      <kwdata>01000000</kwdata>
+    </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar_vcfg_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_vcfg_record.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="VCFG">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VCFG</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="B1">
+      <kwdesc>Base eMAC Address</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>64</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="NV">
+      <kwdesc>NVLink Configuration Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>255</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar_ver0_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_ver0_record.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!-- 2019-01-11 myl:  Create -->
+
+<record name="VER0">
+    <rdesc>The Vendor repair data record</rdesc>
+
+    <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VER0</kwdata>
+    </keyword>
+
+    <keyword name="#I">
+      <kwdesc>Repair Data </kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>198</kwlen>
+      <kwdata>455202062000</kwdata>
+    </keyword>
+
+</record>
+

--- a/examples/p9p/sysplanar/p9p_sysplanar_vndr_record.xml
+++ b/examples/p9p/sysplanar/p9p_sysplanar_vndr_record.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-01-11:  Create-->
+
+<record name="VNDR">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+


### PR DESCRIPTION
FRU VPD template example for system planar, openBMC and a generic FRU
for system with P9 prime.

bug:  NA
branch:  master

Signed-off-by: Michael Y. Lim <youhour@us.ibm.com>