### PR TITLE
Add power FRU VPD template and miscellaneous update for Axone FRU VPD

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -49,6 +49,9 @@ p9a/openbmc:      This is an example of an OpenBMC FRU VPD template for a system
 p9a/genericfru    This is an example of a generic FRU VPD template for a system with 
                   Axone processor
 
+p9a/powerfru      This is an example of a power, power supply or VRM card, FRU VPD 
+                  template for a system with Axone processor.
+
 Syntax Examples
 ===============
 bindatainput:     Shows the syntax to have a binary input file for the keyword

--- a/examples/p9a/openbmc/p9a_obmc_opfr_record.xml
+++ b/examples/p9a/openbmc/p9a_obmc_opfr_record.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <!-- myl:  2019-01-11:  Create-->
+<!-- myl:  2019-02-12:  Add TS keyword. -->
+<!--       VD value is not changed because VPD image has not been released -->
 
 <record name="OPFR">
 <rdesc>The OPFR record</rdesc>
@@ -72,6 +74,13 @@
       <kwformat>hex</kwformat>
       <kwlen>2</kwlen>
       <kwdata>0001</kwdata>
+   </keyword>
+
+   <keyword name="TS">
+      <kwdesc>Technology Source</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>00</kwdata>
    </keyword>
 
 </record>

--- a/examples/p9a/powerfru/p9a_powerfru.tvpd
+++ b/examples/p9a/powerfru/p9a_powerfru.tvpd
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+  <!-- Power subsystem FRU VPD for a system with the next generation IBM POWER chip, Axone -->
+  <!-- Requires 16 Kbytes eeprom -->
+  <!-- myl:  2019-02-12:  Create -->
+
+<vpd>
+
+  <name>FILENAME</name>
+  <size>16kb</size>
+  <VD>01</VD>
+
+  <record name="OPFR">
+    <rtvpdfile>p9a_powerfru_opfr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VNDR">
+    <rtvpdfile>p9a_powerfru_vndr_record.xml</rtvpdfile>
+  </record>
+
+  <record name="VPRI">
+    <rtvpdfile>p9a_powerfru_vpri_record.xml</rtvpdfile>
+  </record>
+
+</vpd>

--- a/examples/p9a/powerfru/p9a_powerfru_opfr_record.xml
+++ b/examples/p9a/powerfru/p9a_powerfru_opfr_record.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
-<!-- myl:  2019-01-11:  Create-->
-<!-- myl:  2019-02-12:  Add TS keyword. -->
-<!--       VD value is not changed because VPD image has not been released -->
+<!-- myl:  2019-02-12:  Create-->
 
 <record name="OPFR">
 <rdesc>The OPFR record</rdesc>

--- a/examples/p9a/powerfru/p9a_powerfru_vndr_record.xml
+++ b/examples/p9a/powerfru/p9a_powerfru_vndr_record.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-02-12:  Create-->
+
+<record name="VNDR">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VNDR</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="IN">
+      <kwdesc>Vendor Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>128</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9a/powerfru/p9a_powerfru_vpri_record.xml
+++ b/examples/p9a/powerfru/p9a_powerfru_vpri_record.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!-- myl:  2019-02-12:  Create-->
+
+<record name="VPRI">
+<rdesc>The VNDR record</rdesc>
+
+   <keyword name="RT">
+      <kwdesc>The Record Type keyword</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>VPRI</kwdata>
+   </keyword>
+
+   <keyword name="VD">
+      <kwdesc>Record Version</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>2</kwlen>
+      <kwdata>01</kwdata>
+   </keyword>
+
+   <keyword name="CR">
+      <kwdesc>Calibration Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>255</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+   <keyword name="#D">
+      <kwdesc>Card Specific Data</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>8192</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
+
+</record>
+

--- a/examples/p9a/sysplanar/p9a_sysplanar.tvpd
+++ b/examples/p9a/sysplanar/p9a_sysplanar.tvpd
@@ -5,7 +5,7 @@
 <vpd>
 
   <name>FILENAME</name>
-  <size>64kb</size>
+  <size>16kb</size>
   <VD>01</VD>
 
   <record name="OSYS">

--- a/examples/p9a/sysplanar/p9a_sysplanar_opfr_record.xml
+++ b/examples/p9a/sysplanar/p9a_sysplanar_opfr_record.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <!-- myl:  2019-01-11:  Create-->
+<!-- myl:  2019-02-12:  Add TS keyword. -->
+<!--       VD value is not changed because VPD image has not been released -->
 
 <record name="OPFR">
 <rdesc>The OPFR record</rdesc>
@@ -73,6 +75,13 @@
       <kwlen>2</kwlen>
       <kwdata>0001</kwdata>
     </keyword>
+
+   <keyword name="TS">
+      <kwdesc>Technology Source</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>1</kwlen>
+      <kwdata>00</kwdata>
+   </keyword>
 
 </record>
 

--- a/examples/p9a/sysplanar/p9a_sysplanar_osys_record.xml
+++ b/examples/p9a/sysplanar/p9a_sysplanar_osys_record.xml
@@ -67,5 +67,19 @@
       <kwdata>01000000</kwdata>
     </keyword>
 
+    <keyword name="ZZ">
+      <kwdesc>OEM System Serial Number</kwdesc>
+      <kwformat>ascii</kwformat>
+      <kwlen>16</kwlen>
+      <kwdata>0000000000000000</kwdata>
+    </keyword>
+
+    <keyword name="D4">
+      <kwdesc>Reserved</kwdesc>
+      <kwformat>hex</kwformat>
+      <kwlen>4</kwlen>
+      <kwdata>00000000</kwdata>
+    </keyword>
+
 </record>
 


### PR DESCRIPTION
       -Add power FRU VPD template
       -Update readme file to include power FRU info
       -Add 'TS' keyword to opfr records of all the FRU VPD templates
       -Add 'ZZ' and 'D4' keyword to osys record
       -Change system vpd size to 16 Kbytes.

bug:  NA
branch:  master

Signed-off-by: Michael Y. Lim <youhour@us.ibm.com>